### PR TITLE
Cleanup json_atlas.gd

### DIFF
--- a/addons/json-atlas/json_atlas.gd
+++ b/addons/json-atlas/json_atlas.gd
@@ -1,78 +1,93 @@
 @tool
 extends AtlasTexture
+## Draws an [member AtlastTexture] based on a given [Texture2D] [member source_image] and it's
+## associated [JSON] [member json_file].
 class_name JSONAtlasTexture
 
-@export var frame: String: ## Frame, what be rendered.
-	set = set_frame
+## The name of the Frame that will be rendered.
+@export var frame: String: set = set_frame
+
 @export_group("Data")
-@export var source_image: Texture2D: ## The source image from which the image will be taken for output.
-	set(v):
-		source_image = v
-		atlas = v
-		if v:
-			var path = source_image.resource_path.replace(
-				source_image.resource_path.get_extension(),
-				"json"
-			)
-			if FileAccess.file_exists(path):
-				json_file = load(path)
-			else:
-				printerr("JSON file for `%s` doesn`t exist!" % source_image.resource_path.get_file())
-		else: json_file = null
-		notify_property_list_changed()
+## The source [Texture2D] image from which the image will be taken for output.
+@export var source_image: Texture2D: set = set_source_image
 		
-@export var json_file: JSON: ## JSON file with atlas data.
-	set(v):
-		var old_json: JSON = json_file
-		json_file = v
-		if !v.changed.is_connected(_update_json):
-			v.changed.connect(_update_json)
-		if v: _load_json()
-		else: old_json.changed.disconnect(_update_json)
-		
+## [JSON] file with the atlas data for the [member source_image].
+@export var json_file: JSON: set = set_json_file
 
-@export_storage var frames: Dictionary
+## Stores the [Rect2i] frames to be used within the animation.
+@export_storage var frames: Dictionary#[String, Rect2i]
 
-## Loads JSON and gets a Frames data.
-func _load_json():
-	if json_file.data.has("frames"):
-		if json_file.data is Dictionary:
-			frames.clear()
-			var data: Dictionary = json_file.data
-			for frm in json_file.data.frames:
-				frames[frm] = Rect2i(
-					data.frames[frm].frame.x,
-					data.frames[frm].frame.y,
-					data.frames[frm].frame.w,
-					data.frames[frm].frame.h,
-				)
+## Sets the [member source_image] to the given [Texture2D] [param given_image].
+func set_source_image(given_image: Texture2D) -> void:
+	source_image = given_image
+	atlas = given_image
+	if given_image:
+		var path: String = source_image.resource_path.replace(source_image.resource_path.get_extension(), "json")
+		if FileAccess.file_exists(path):
+			json_file = load(path)
 		else:
-			printerr("JSONAtalsTexture not supported `Array`!")
+			printerr("JSON file for `%s` doesn`t exist!" % source_image.resource_path.get_file())
 	else:
-		printerr("JSON file has`t frames data!")
+		json_file = null
+	notify_property_list_changed()
 
-## Set current frame.
-func set_frame(new_frame: String):
-	if frames.has(new_frame):
-		frame = new_frame
-		region = frames[frame]
+## Sets the [member json_file] to the given [JSON] [param given_file].
+func set_json_file(given_file: JSON) -> void:
+	var old_json: JSON = json_file
+	json_file = given_file
+	if !given_file.changed.is_connected(_update_json):
+		given_file.changed.connect(_update_json)
+	if given_file:
+		_load_json()
+	else:
+		old_json.changed.disconnect(_update_json)
 
-## Just make enum of frames. (only for `frame`)
-func _get_frames_enum() -> String:
-	var result: String
+## Set current [member frame] to the given [String] [param new_frame].
+func set_frame(new_frame: String) -> void:
+	if !frames.has(new_frame):
+		printerr("Frame \""+new_frame+"\" not found!")
+		return
+	frame = new_frame
+	region = frames[frame]
+
+## Loads the [member json_file] and gets frame data.
+func _load_json() -> void:
+	if !json_file.data.has("frames"):
+		printerr("Provided JSON file has no frame data!")
+		return
+	if !json_file.data is Dictionary:
+		printerr("JSONAtlasTexture only supports Dictionaries!")
+		return
+	frames.clear()
+	var data: Dictionary = json_file.data
+	for frm: int in json_file.data.frames:
+		frames[frm] = Rect2i(
+			data.frames[frm].frame.x,
+			data.frames[frm].frame.y,
+			data.frames[frm].frame.w,
+			data.frames[frm].frame.h,
+		)
+
+## Creates a [String] hint-string of frame titles.
+## [br]Used for the [member frame]'s export property, see [method _validate_property].
+func _get_frames_hint_string() -> String:
+	var result: String = ""
 	for frm in frames.keys():
-		if result: result += ",%s" % frm
-		else: result = frm
-	
+		if result:
+			result += ",%s" % frm
+		else:
+			result = frm
 	return result
+
+## Reloads the [member json_file] if changed.
+func _update_json() -> void:
+	json_file = load(json_file.resource_path)
 
 func _validate_property(property: Dictionary) -> void:
 	match property.name:
 		"frame":
 			property.hint = PROPERTY_HINT_ENUM
-			property.hint_string = _get_frames_enum()
-		"atlas", "region": property.usage = PROPERTY_USAGE_NO_EDITOR ## Just hide default [AtlasTexture] properties.
-
-## If your json has been updated.
-func _update_json():
-	json_file = load(json_file.resource_path)
+			property.hint_string = _get_frames_hint_string()
+		# Hiding default [AtlasTexture] properties.
+		"atlas", "region":
+			property.usage = PROPERTY_USAGE_NO_EDITOR

--- a/addons/json-atlas/json_atlas.gd
+++ b/addons/json-atlas/json_atlas.gd
@@ -4,6 +4,9 @@ extends AtlasTexture
 ## associated [JSON] [member json_file].
 class_name JSONAtlasTexture
 
+## Signal emitted once the [member frames] have been populated.
+signal frames_compiled
+
 ## The name of the Frame that will be rendered.
 @export var frame: String: set = set_frame
 
@@ -44,6 +47,8 @@ func set_json_file(given_file: JSON) -> void:
 
 ## Set current [member frame] to the given [String] [param new_frame].
 func set_frame(new_frame: String) -> void:
+	if frames.is_empty():
+		await frames_compiled
 	if !frames.has(new_frame):
 		printerr("Frame \""+new_frame+"\" not found!")
 		return
@@ -60,19 +65,20 @@ func _load_json() -> void:
 		return
 	frames.clear()
 	var data: Dictionary = json_file.data
-	for frm: int in json_file.data.frames:
+	for frm: String in json_file.data.frames:
 		frames[frm] = Rect2i(
 			data.frames[frm].frame.x,
 			data.frames[frm].frame.y,
 			data.frames[frm].frame.w,
 			data.frames[frm].frame.h,
 		)
+	frames_compiled.emit()
 
 ## Creates a [String] hint-string of frame titles.
 ## [br]Used for the [member frame]'s export property, see [method _validate_property].
 func _get_frames_hint_string() -> String:
 	var result: String = ""
-	for frm in frames.keys():
+	for frm: String in frames.keys():
 		if result:
 			result += ",%s" % frm
 		else:


### PR DESCRIPTION
I cleaned up the main `json_atlas.gd` file. Here is a rundown of my changes:
## Added
- Added documentation for the class itself.
- Added typed documentation for every method.
- Added empty `frames` check to the `set_frame` method.
- Added types to most variables (ignored dictionaries to keep <4.4 support)
## Modified
- Removed redundant nesting for cleaner code.
- Made documentation consistent.
- Made `set` methods consistent.